### PR TITLE
Add random jitter to scan and join delay to appear more natural

### DIFF
--- a/Scraps/Controls/SettingsControl.Designer.cs
+++ b/Scraps/Controls/SettingsControl.Designer.cs
@@ -356,8 +356,8 @@ namespace Scraps.Controls
             this.label9.Name = "label9";
             this.label9.Size = new System.Drawing.Size(845, 16);
             this.label9.TabIndex = 27;
-            this.label9.Text = "Add a random value between zero and this setting to each scan to appear more natu" +
-    "ral. 0 to disable.";
+            this.label9.Text = "Adds \"jitter\" to the time between raffle joins to seem more human. 0 to disable, " +
+    "or integer to set maximum variation.";
             // 
             // label10
             // 
@@ -379,8 +379,8 @@ namespace Scraps.Controls
             this.label11.Name = "label11";
             this.label11.Size = new System.Drawing.Size(845, 16);
             this.label11.TabIndex = 26;
-            this.label11.Text = "Add a random value between zero and this setting to each scan to appear more natu" +
-    "ral. 0 to disable.";
+            this.label11.Text = "Adds \"jitter\" to the scan delay to seem more human. 0 to disable, or integer to s" +
+    "et maximum variation.";
             // 
             // _JoinJitterInput
             // 

--- a/Scraps/Controls/SettingsControl.Designer.cs
+++ b/Scraps/Controls/SettingsControl.Designer.cs
@@ -50,10 +50,18 @@ namespace Scraps.Controls
             this._CheckUpdatesToggle = new System.Windows.Forms.CheckBox();
             this._FetchAnnouncementsToggle = new System.Windows.Forms.CheckBox();
             this._SettingsParentPanel = new System.Windows.Forms.Panel();
+            this.label8 = new System.Windows.Forms.Label();
+            this._ScanJitterInput = new System.Windows.Forms.NumericUpDown();
+            this.label9 = new System.Windows.Forms.Label();
+            this.label10 = new System.Windows.Forms.Label();
+            this.label11 = new System.Windows.Forms.Label();
+            this._JoinJitterInput = new System.Windows.Forms.NumericUpDown();
             ((System.ComponentModel.ISupportInitialize)(this._ScanDelayInput)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this._PaginateDelayInput)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this._JoinDelayInput)).BeginInit();
             this._SettingsParentPanel.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this._ScanJitterInput)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this._JoinJitterInput)).BeginInit();
             this.SuspendLayout();
             // 
             // _SaveSettingsButton
@@ -193,22 +201,22 @@ namespace Scraps.Controls
             // _RaffleSortByNewToggle
             // 
             this._RaffleSortByNewToggle.AutoSize = true;
-            this._RaffleSortByNewToggle.Location = new System.Drawing.Point(102, 251);
+            this._RaffleSortByNewToggle.Location = new System.Drawing.Point(102, 399);
             this._RaffleSortByNewToggle.Margin = new System.Windows.Forms.Padding(3, 3, 3, 6);
             this._RaffleSortByNewToggle.Name = "_RaffleSortByNewToggle";
             this._RaffleSortByNewToggle.Size = new System.Drawing.Size(171, 19);
-            this._RaffleSortByNewToggle.TabIndex = 11;
+            this._RaffleSortByNewToggle.TabIndex = 14;
             this._RaffleSortByNewToggle.Text = "Sort raffles by newer entries";
             this._RaffleSortByNewToggle.UseVisualStyleBackColor = true;
             // 
             // _ParanoidModeToggle
             // 
             this._ParanoidModeToggle.AutoSize = true;
-            this._ParanoidModeToggle.Location = new System.Drawing.Point(102, 279);
+            this._ParanoidModeToggle.Location = new System.Drawing.Point(102, 427);
             this._ParanoidModeToggle.Margin = new System.Windows.Forms.Padding(3, 3, 3, 6);
             this._ParanoidModeToggle.Name = "_ParanoidModeToggle";
             this._ParanoidModeToggle.Size = new System.Drawing.Size(145, 19);
-            this._ParanoidModeToggle.TabIndex = 12;
+            this._ParanoidModeToggle.TabIndex = 15;
             this._ParanoidModeToggle.Text = "Enable paranoid mode";
             this._ParanoidModeToggle.UseVisualStyleBackColor = true;
             // 
@@ -250,33 +258,33 @@ namespace Scraps.Controls
             // _TopmostToggle
             // 
             this._TopmostToggle.AutoSize = true;
-            this._TopmostToggle.Location = new System.Drawing.Point(102, 307);
+            this._TopmostToggle.Location = new System.Drawing.Point(102, 455);
             this._TopmostToggle.Margin = new System.Windows.Forms.Padding(3, 3, 3, 6);
             this._TopmostToggle.Name = "_TopmostToggle";
             this._TopmostToggle.Size = new System.Drawing.Size(157, 19);
-            this._TopmostToggle.TabIndex = 19;
+            this._TopmostToggle.TabIndex = 16;
             this._TopmostToggle.Text = "Window is always on top";
             this._TopmostToggle.UseVisualStyleBackColor = true;
             // 
             // _CheckUpdatesToggle
             // 
             this._CheckUpdatesToggle.AutoSize = true;
-            this._CheckUpdatesToggle.Location = new System.Drawing.Point(102, 335);
+            this._CheckUpdatesToggle.Location = new System.Drawing.Point(102, 483);
             this._CheckUpdatesToggle.Margin = new System.Windows.Forms.Padding(3, 3, 3, 6);
             this._CheckUpdatesToggle.Name = "_CheckUpdatesToggle";
             this._CheckUpdatesToggle.Size = new System.Drawing.Size(197, 19);
-            this._CheckUpdatesToggle.TabIndex = 20;
+            this._CheckUpdatesToggle.TabIndex = 17;
             this._CheckUpdatesToggle.Text = "Check for updates automatically";
             this._CheckUpdatesToggle.UseVisualStyleBackColor = true;
             // 
             // _FetchAnnouncementsToggle
             // 
             this._FetchAnnouncementsToggle.AutoSize = true;
-            this._FetchAnnouncementsToggle.Location = new System.Drawing.Point(102, 363);
+            this._FetchAnnouncementsToggle.Location = new System.Drawing.Point(102, 511);
             this._FetchAnnouncementsToggle.Margin = new System.Windows.Forms.Padding(3, 3, 6, 6);
             this._FetchAnnouncementsToggle.Name = "_FetchAnnouncementsToggle";
             this._FetchAnnouncementsToggle.Size = new System.Drawing.Size(201, 19);
-            this._FetchAnnouncementsToggle.TabIndex = 21;
+            this._FetchAnnouncementsToggle.TabIndex = 18;
             this._FetchAnnouncementsToggle.Text = "Fetch announcements on startup";
             this._FetchAnnouncementsToggle.UseVisualStyleBackColor = true;
             // 
@@ -286,6 +294,12 @@ namespace Scraps.Controls
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this._SettingsParentPanel.AutoScroll = true;
+            this._SettingsParentPanel.Controls.Add(this.label8);
+            this._SettingsParentPanel.Controls.Add(this._ScanJitterInput);
+            this._SettingsParentPanel.Controls.Add(this.label9);
+            this._SettingsParentPanel.Controls.Add(this.label10);
+            this._SettingsParentPanel.Controls.Add(this.label11);
+            this._SettingsParentPanel.Controls.Add(this._JoinJitterInput);
             this._SettingsParentPanel.Controls.Add(this.label1);
             this._SettingsParentPanel.Controls.Add(this._FetchAnnouncementsToggle);
             this._SettingsParentPanel.Controls.Add(this.label3);
@@ -309,6 +323,78 @@ namespace Scraps.Controls
             this._SettingsParentPanel.Size = new System.Drawing.Size(956, 575);
             this._SettingsParentPanel.TabIndex = 22;
             // 
+            // label8
+            // 
+            this.label8.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.label8.AutoSize = true;
+            this.label8.Location = new System.Drawing.Point(9, 255);
+            this.label8.Name = "label8";
+            this.label8.Size = new System.Drawing.Size(62, 15);
+            this.label8.TabIndex = 22;
+            this.label8.Text = "Scan jitter:";
+            // 
+            // _ScanJitterInput
+            // 
+            this._ScanJitterInput.Location = new System.Drawing.Point(102, 251);
+            this._ScanJitterInput.Margin = new System.Windows.Forms.Padding(3, 3, 3, 6);
+            this._ScanJitterInput.Maximum = new decimal(new int[] {
+            -1,
+            -1,
+            -1,
+            0});
+            this._ScanJitterInput.Name = "_ScanJitterInput";
+            this._ScanJitterInput.Size = new System.Drawing.Size(135, 23);
+            this._ScanJitterInput.TabIndex = 11;
+            // 
+            // label9
+            // 
+            this.label9.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.label9.Location = new System.Drawing.Point(102, 346);
+            this.label9.Margin = new System.Windows.Forms.Padding(3, 0, 3, 18);
+            this.label9.Name = "label9";
+            this.label9.Size = new System.Drawing.Size(845, 16);
+            this.label9.TabIndex = 27;
+            this.label9.Text = "Add a random value between zero and this setting to each scan to appear more natu" +
+    "ral. 0 to disable.";
+            // 
+            // label10
+            // 
+            this.label10.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.label10.AutoSize = true;
+            this.label10.Location = new System.Drawing.Point(9, 321);
+            this.label10.Name = "label10";
+            this.label10.Size = new System.Drawing.Size(58, 15);
+            this.label10.TabIndex = 24;
+            this.label10.Text = "Join jitter:";
+            // 
+            // label11
+            // 
+            this.label11.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.label11.Location = new System.Drawing.Point(102, 280);
+            this.label11.Margin = new System.Windows.Forms.Padding(3, 0, 3, 18);
+            this.label11.Name = "label11";
+            this.label11.Size = new System.Drawing.Size(845, 16);
+            this.label11.TabIndex = 26;
+            this.label11.Text = "Add a random value between zero and this setting to each scan to appear more natu" +
+    "ral. 0 to disable.";
+            // 
+            // _JoinJitterInput
+            // 
+            this._JoinJitterInput.Location = new System.Drawing.Point(102, 317);
+            this._JoinJitterInput.Margin = new System.Windows.Forms.Padding(3, 3, 3, 6);
+            this._JoinJitterInput.Maximum = new decimal(new int[] {
+            -1,
+            -1,
+            -1,
+            0});
+            this._JoinJitterInput.Name = "_JoinJitterInput";
+            this._JoinJitterInput.Size = new System.Drawing.Size(135, 23);
+            this._JoinJitterInput.TabIndex = 13;
+            // 
             // SettingsControl
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
@@ -325,6 +411,8 @@ namespace Scraps.Controls
             ((System.ComponentModel.ISupportInitialize)(this._JoinDelayInput)).EndInit();
             this._SettingsParentPanel.ResumeLayout(false);
             this._SettingsParentPanel.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this._ScanJitterInput)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this._JoinJitterInput)).EndInit();
             this.ResumeLayout(false);
 
         }
@@ -351,5 +439,11 @@ namespace Scraps.Controls
         private CheckBox _CheckUpdatesToggle;
         private CheckBox _FetchAnnouncementsToggle;
         private Panel _SettingsParentPanel;
+        private Label label8;
+        private NumericUpDown _ScanJitterInput;
+        private Label label9;
+        private Label label10;
+        private Label label11;
+        private NumericUpDown _JoinJitterInput;
     }
 }

--- a/Scraps/Controls/SettingsControl.Designer.cs
+++ b/Scraps/Controls/SettingsControl.Designer.cs
@@ -71,7 +71,7 @@ namespace Scraps.Controls
             this._SaveSettingsButton.Location = new System.Drawing.Point(767, 584);
             this._SaveSettingsButton.Name = "_SaveSettingsButton";
             this._SaveSettingsButton.Size = new System.Drawing.Size(90, 24);
-            this._SaveSettingsButton.TabIndex = 0;
+            this._SaveSettingsButton.TabIndex = 12;
             this._SaveSettingsButton.Text = "Save";
             this._SaveSettingsButton.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             this._SaveSettingsButton.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
@@ -85,7 +85,7 @@ namespace Scraps.Controls
             this._ResetSettingsButton.Location = new System.Drawing.Point(863, 584);
             this._ResetSettingsButton.Name = "_ResetSettingsButton";
             this._ResetSettingsButton.Size = new System.Drawing.Size(90, 24);
-            this._ResetSettingsButton.TabIndex = 1;
+            this._ResetSettingsButton.TabIndex = 13;
             this._ResetSettingsButton.Text = "Reset";
             this._ResetSettingsButton.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             this._ResetSettingsButton.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
@@ -129,7 +129,7 @@ namespace Scraps.Controls
             0});
             this._ScanDelayInput.Name = "_ScanDelayInput";
             this._ScanDelayInput.Size = new System.Drawing.Size(135, 23);
-            this._ScanDelayInput.TabIndex = 4;
+            this._ScanDelayInput.TabIndex = 1;
             // 
             // label2
             // 
@@ -145,7 +145,7 @@ namespace Scraps.Controls
             this.label3.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(9, 123);
+            this.label3.Location = new System.Drawing.Point(9, 321);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(87, 15);
             this.label3.TabIndex = 6;
@@ -153,7 +153,7 @@ namespace Scraps.Controls
             // 
             // _PaginateDelayInput
             // 
-            this._PaginateDelayInput.Location = new System.Drawing.Point(102, 119);
+            this._PaginateDelayInput.Location = new System.Drawing.Point(102, 317);
             this._PaginateDelayInput.Margin = new System.Windows.Forms.Padding(3, 3, 3, 6);
             this._PaginateDelayInput.Maximum = new decimal(new int[] {
             -1,
@@ -162,7 +162,7 @@ namespace Scraps.Controls
             0});
             this._PaginateDelayInput.Name = "_PaginateDelayInput";
             this._PaginateDelayInput.Size = new System.Drawing.Size(135, 23);
-            this._PaginateDelayInput.TabIndex = 7;
+            this._PaginateDelayInput.TabIndex = 6;
             // 
             // label4
             // 
@@ -186,7 +186,7 @@ namespace Scraps.Controls
             0});
             this._JoinDelayInput.Name = "_JoinDelayInput";
             this._JoinDelayInput.Size = new System.Drawing.Size(135, 23);
-            this._JoinDelayInput.TabIndex = 9;
+            this._JoinDelayInput.TabIndex = 4;
             // 
             // _AutoIncrementScanDelayToggle
             // 
@@ -194,7 +194,7 @@ namespace Scraps.Controls
             this._AutoIncrementScanDelayToggle.Location = new System.Drawing.Point(246, 55);
             this._AutoIncrementScanDelayToggle.Name = "_AutoIncrementScanDelayToggle";
             this._AutoIncrementScanDelayToggle.Size = new System.Drawing.Size(111, 19);
-            this._AutoIncrementScanDelayToggle.TabIndex = 10;
+            this._AutoIncrementScanDelayToggle.TabIndex = 2;
             this._AutoIncrementScanDelayToggle.Text = "Auto-increment";
             this._AutoIncrementScanDelayToggle.UseVisualStyleBackColor = true;
             // 
@@ -205,7 +205,7 @@ namespace Scraps.Controls
             this._RaffleSortByNewToggle.Margin = new System.Windows.Forms.Padding(3, 3, 3, 6);
             this._RaffleSortByNewToggle.Name = "_RaffleSortByNewToggle";
             this._RaffleSortByNewToggle.Size = new System.Drawing.Size(171, 19);
-            this._RaffleSortByNewToggle.TabIndex = 14;
+            this._RaffleSortByNewToggle.TabIndex = 7;
             this._RaffleSortByNewToggle.Text = "Sort raffles by newer entries";
             this._RaffleSortByNewToggle.UseVisualStyleBackColor = true;
             // 
@@ -216,7 +216,7 @@ namespace Scraps.Controls
             this._ParanoidModeToggle.Margin = new System.Windows.Forms.Padding(3, 3, 3, 6);
             this._ParanoidModeToggle.Name = "_ParanoidModeToggle";
             this._ParanoidModeToggle.Size = new System.Drawing.Size(145, 19);
-            this._ParanoidModeToggle.TabIndex = 15;
+            this._ParanoidModeToggle.TabIndex = 8;
             this._ParanoidModeToggle.Text = "Enable paranoid mode";
             this._ParanoidModeToggle.UseVisualStyleBackColor = true;
             // 
@@ -236,7 +236,7 @@ namespace Scraps.Controls
             // 
             this.label6.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.label6.Location = new System.Drawing.Point(102, 148);
+            this.label6.Location = new System.Drawing.Point(102, 346);
             this.label6.Margin = new System.Windows.Forms.Padding(3, 0, 3, 18);
             this.label6.Name = "label6";
             this.label6.Size = new System.Drawing.Size(845, 16);
@@ -262,7 +262,7 @@ namespace Scraps.Controls
             this._TopmostToggle.Margin = new System.Windows.Forms.Padding(3, 3, 3, 6);
             this._TopmostToggle.Name = "_TopmostToggle";
             this._TopmostToggle.Size = new System.Drawing.Size(157, 19);
-            this._TopmostToggle.TabIndex = 16;
+            this._TopmostToggle.TabIndex = 9;
             this._TopmostToggle.Text = "Window is always on top";
             this._TopmostToggle.UseVisualStyleBackColor = true;
             // 
@@ -273,7 +273,7 @@ namespace Scraps.Controls
             this._CheckUpdatesToggle.Margin = new System.Windows.Forms.Padding(3, 3, 3, 6);
             this._CheckUpdatesToggle.Name = "_CheckUpdatesToggle";
             this._CheckUpdatesToggle.Size = new System.Drawing.Size(197, 19);
-            this._CheckUpdatesToggle.TabIndex = 17;
+            this._CheckUpdatesToggle.TabIndex = 10;
             this._CheckUpdatesToggle.Text = "Check for updates automatically";
             this._CheckUpdatesToggle.UseVisualStyleBackColor = true;
             // 
@@ -284,7 +284,7 @@ namespace Scraps.Controls
             this._FetchAnnouncementsToggle.Margin = new System.Windows.Forms.Padding(3, 3, 6, 6);
             this._FetchAnnouncementsToggle.Name = "_FetchAnnouncementsToggle";
             this._FetchAnnouncementsToggle.Size = new System.Drawing.Size(201, 19);
-            this._FetchAnnouncementsToggle.TabIndex = 18;
+            this._FetchAnnouncementsToggle.TabIndex = 11;
             this._FetchAnnouncementsToggle.Text = "Fetch announcements on startup";
             this._FetchAnnouncementsToggle.UseVisualStyleBackColor = true;
             // 
@@ -328,7 +328,7 @@ namespace Scraps.Controls
             this.label8.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.label8.AutoSize = true;
-            this.label8.Location = new System.Drawing.Point(9, 255);
+            this.label8.Location = new System.Drawing.Point(9, 123);
             this.label8.Name = "label8";
             this.label8.Size = new System.Drawing.Size(62, 15);
             this.label8.TabIndex = 22;
@@ -336,7 +336,7 @@ namespace Scraps.Controls
             // 
             // _ScanJitterInput
             // 
-            this._ScanJitterInput.Location = new System.Drawing.Point(102, 251);
+            this._ScanJitterInput.Location = new System.Drawing.Point(102, 119);
             this._ScanJitterInput.Margin = new System.Windows.Forms.Padding(3, 3, 3, 6);
             this._ScanJitterInput.Maximum = new decimal(new int[] {
             -1,
@@ -345,13 +345,13 @@ namespace Scraps.Controls
             0});
             this._ScanJitterInput.Name = "_ScanJitterInput";
             this._ScanJitterInput.Size = new System.Drawing.Size(135, 23);
-            this._ScanJitterInput.TabIndex = 11;
+            this._ScanJitterInput.TabIndex = 3;
             // 
             // label9
             // 
             this.label9.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.label9.Location = new System.Drawing.Point(102, 346);
+            this.label9.Location = new System.Drawing.Point(102, 280);
             this.label9.Margin = new System.Windows.Forms.Padding(3, 0, 3, 18);
             this.label9.Name = "label9";
             this.label9.Size = new System.Drawing.Size(845, 16);
@@ -364,7 +364,7 @@ namespace Scraps.Controls
             this.label10.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.label10.AutoSize = true;
-            this.label10.Location = new System.Drawing.Point(9, 321);
+            this.label10.Location = new System.Drawing.Point(9, 255);
             this.label10.Name = "label10";
             this.label10.Size = new System.Drawing.Size(58, 15);
             this.label10.TabIndex = 24;
@@ -374,7 +374,7 @@ namespace Scraps.Controls
             // 
             this.label11.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.label11.Location = new System.Drawing.Point(102, 280);
+            this.label11.Location = new System.Drawing.Point(102, 148);
             this.label11.Margin = new System.Windows.Forms.Padding(3, 0, 3, 18);
             this.label11.Name = "label11";
             this.label11.Size = new System.Drawing.Size(845, 16);
@@ -384,7 +384,7 @@ namespace Scraps.Controls
             // 
             // _JoinJitterInput
             // 
-            this._JoinJitterInput.Location = new System.Drawing.Point(102, 317);
+            this._JoinJitterInput.Location = new System.Drawing.Point(102, 251);
             this._JoinJitterInput.Margin = new System.Windows.Forms.Padding(3, 3, 3, 6);
             this._JoinJitterInput.Maximum = new decimal(new int[] {
             -1,
@@ -393,7 +393,7 @@ namespace Scraps.Controls
             0});
             this._JoinJitterInput.Name = "_JoinJitterInput";
             this._JoinJitterInput.Size = new System.Drawing.Size(135, 23);
-            this._JoinJitterInput.TabIndex = 13;
+            this._JoinJitterInput.TabIndex = 5;
             // 
             // SettingsControl
             // 

--- a/Scraps/Controls/SettingsControl.cs
+++ b/Scraps/Controls/SettingsControl.cs
@@ -44,6 +44,8 @@ public partial class SettingsControl : UserControl
         _ScanDelayInput.Value                 = _settings.GetInt("ScanDelay");
         _PaginateDelayInput.Value             = _settings.GetInt("PaginateDelay");
         _JoinDelayInput.Value                 = _settings.GetInt("JoinDelay");
+        _JoinJitterInput.Value                = _settings.GetInt("JoinJitter");
+        _ScanJitterInput.Value                = _settings.GetInt("ScanJitter");
         _RaffleSortByNewToggle.Checked        = _settings.GetBool("SortByNew");
         _AutoIncrementScanDelayToggle.Checked = _settings.GetBool("IncrementScanDelay");
         _ParanoidModeToggle.Checked           = _settings.GetBool("Paranoid");
@@ -76,6 +78,8 @@ public partial class SettingsControl : UserControl
         int    scanDelay          = (int)_ScanDelayInput.Value;
         int    paginateDelay      = (int)_PaginateDelayInput.Value;
         int    joinDelay          = (int)_JoinDelayInput.Value;
+        int    joinJitter         = (int)_JoinJitterInput.Value;
+        int    scanJitter         = (int)_ScanJitterInput.Value;
         bool   sortByNew          = _RaffleSortByNewToggle.Checked;
         bool   incrementScanDelay = _AutoIncrementScanDelayToggle.Checked;
         bool   paranoid           = _ParanoidModeToggle.Checked;
@@ -94,6 +98,8 @@ public partial class SettingsControl : UserControl
             .Set("ScanDelay", scanDelay)
             .Set("PaginateDelay", paginateDelay)
             .Set("JoinDelay", joinDelay)
+            .Set("JoinJitter", joinJitter)
+            .Set("ScanJitter", scanJitter)
             .Set("IncrementScanDelay", incrementScanDelay)
             .Set("SortByNew", sortByNew)
             .Set("Paranoid", paranoid)

--- a/Scraps/Forms/MainForm.cs
+++ b/Scraps/Forms/MainForm.cs
@@ -51,7 +51,7 @@ public sealed partial class MainForm : Form
         InitializeComponent();
 
         Text        = GlobalShared.WindowTitle;
-        MinimumSize = new Size(900, 525);
+        MinimumSize = new Size(900, 700);
         
         _MainWindowTabs.SizeMode = TabSizeMode.Fixed;
         _MainWindowTabs.ImageList = new ImageList

--- a/Scraps/Scraps.csproj
+++ b/Scraps/Scraps.csproj
@@ -13,8 +13,8 @@
     <Company>Caprine Logic</Company>
     <Product>Scraps</Product>
     <ApplicationIcon>Resources\Scraps.ico</ApplicationIcon>
-    <AssemblyVersion>5.3.3.0</AssemblyVersion>
-    <FileVersion>5.3.3.0</FileVersion>
+    <AssemblyVersion>5.3.4.0</AssemblyVersion>
+    <FileVersion>5.3.4.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
   </PropertyGroup>
 

--- a/Scraps/Services/RaffleService.cs
+++ b/Scraps/Services/RaffleService.cs
@@ -107,7 +107,8 @@ public class RaffleService : IDisposable
     private bool                    _alertedOfWonRaffles;
     private CancellationToken       _cancelToken;
     private CancellationTokenSource _cancelTokenSource;
-    
+    private System.Random           _randomifier;
+
     private readonly SettingsService _settings;
     private readonly SoundPlayer     _alertPlayer;
     private readonly Logger          _log             = LogManager.GetCurrentClassLogger();
@@ -120,11 +121,14 @@ public class RaffleService : IDisposable
     private readonly Regex           _entryRegex      = new(@"ScrapTF\.Raffles\.RedirectToRaffle\('(?<RaffleId>[A-Z0-9]{6,})'\)", RegexOptions.Compiled);
     private readonly Regex           _hashRegex       = new(@"EnterRaffle\('(?<RaffleId>[A-Z0-9]{6,})', '(?<RaffleHash>[a-f0-9]{64})'", RegexOptions.Compiled);
     private readonly Regex           _limitRegex      = new(@"total=""(?<Entered>\d+)"" data-max=""(?<Max>\d+)", RegexOptions.Compiled);
+    
+
 
     public RaffleService(SettingsService settings)
     {
         _settings    = settings;
         _alertPlayer = new SoundPlayer(Audio.alert);
+        _randomifier = new System.Random();
     }
     
     ~RaffleService() => Dispose();
@@ -192,14 +196,12 @@ public class RaffleService : IDisposable
 
                 Broadcast("Waiting to scan again");
 
-                System.Random _randomifier = new System.Random();
-                int _modifier = _randomifier.Next(0, 60000); // Adds up to a 60 second delay. 
 
-                int _scanDelayJittered = _scanDelay + _modifier;
+                int scanDelayJittered = _scanDelay + _randomifier.Next(0, _settings.GetInt("ScanJitter"));
 
-                _log.Info("All raffles have been entered, scanning again after {Delay} seconds", _scanDelayJittered / 1000);
+                _log.Info("All raffles have been entered, scanning again after {Delay} seconds", scanDelayJittered / 1000);
 
-                await Task.Delay(_scanDelayJittered,  _cancelToken);
+                await Task.Delay(scanDelayJittered,  _cancelToken);
 
                 if (incrementScanDelay)
                     _scanDelay += 1000;
@@ -503,17 +505,14 @@ public class RaffleService : IDisposable
                     _log.Error("Unable to join raffle {Id}: {Message}", raffle, joinRaffleResponse?.Message ?? "Unknown");
                 }
 
-                System.Random _randomifier = new System.Random();
-                int _joinModifier = _randomifier.Next(0, 10000);
+                int joinDelayJittered = _joinDelay + _randomifier.Next(0, _settings.GetInt("JoinJitter"));
 
-                int _joinDelayJittered = _joinDelay + _joinModifier;
-
-                _log.Info("Waiting for next raffle, attempting to join in {Delay} seconds", _joinDelayJittered / 1000);
+                _log.Info("Waiting for next raffle, attempting to join in {Delay} seconds", joinDelayJittered / 1000);
 
                 Broadcast("Waiting to join next raffle");
 
 
-                await Task.Delay(_joinDelayJittered, _cancelToken);
+                await Task.Delay(joinDelayJittered, _cancelToken);
             }
             else
             {

--- a/Scraps/Services/RaffleService.cs
+++ b/Scraps/Services/RaffleService.cs
@@ -508,7 +508,7 @@ public class RaffleService : IDisposable
                 System.Random _randomifier = new System.Random();
                 int _joinModifier = _randomifier.Next(0, 6000);
 
-                int _joinDelayJittered = _joinDelay + _joinModifier
+                int _joinDelayJittered = _joinDelay + _joinModifier;
 
                 await Task.Delay(_joinDelayJittered, _cancelToken);
             }

--- a/Scraps/Services/RaffleService.cs
+++ b/Scraps/Services/RaffleService.cs
@@ -503,12 +503,15 @@ public class RaffleService : IDisposable
                     _log.Error("Unable to join raffle {Id}: {Message}", raffle, joinRaffleResponse?.Message ?? "Unknown");
                 }
 
-                Broadcast("Waiting to join next raffle");
-
                 System.Random _randomifier = new System.Random();
-                int _joinModifier = _randomifier.Next(0, 6000);
+                int _joinModifier = _randomifier.Next(0, 10000);
 
                 int _joinDelayJittered = _joinDelay + _joinModifier;
+
+                _log.Info("Waiting for next raffle, attempting to join in {Delay} seconds", _joinDelayJittered / 1000);
+
+                Broadcast("Waiting to join next raffle");
+
 
                 await Task.Delay(_joinDelayJittered, _cancelToken);
             }

--- a/Scraps/Services/RaffleService.cs
+++ b/Scraps/Services/RaffleService.cs
@@ -192,9 +192,14 @@ public class RaffleService : IDisposable
 
                 Broadcast("Waiting to scan again");
 
-                _log.Info("All raffles have been entered, scanning again after {Delay} seconds", _scanDelay / 1000);
+                System.Random _randomifier = new System.Random();
+                int _modifier = _randomifier.Next(-30000, 30000); // Adds a 30 second positive or negative delay. 
 
-                await Task.Delay(_scanDelay,  _cancelToken);
+                int _scanDelayJittered = _scanDelay + _modifier;
+
+                _log.Info("All raffles have been entered, scanning again after {Delay} seconds", _scanDelayJittered / 1000);
+
+                await Task.Delay(_scanDelayJittered,  _cancelToken);
 
                 if (incrementScanDelay)
                     _scanDelay += 1000;
@@ -499,8 +504,13 @@ public class RaffleService : IDisposable
                 }
 
                 Broadcast("Waiting to join next raffle");
-                
-                await Task.Delay(_joinDelay, _cancelToken);
+
+                System.Random _randomifier = new System.Random();
+                int _joinModifier = _randomifier.Next(0, 6000);
+
+                int _joinDelayJittered = _joinDelay + _joinModifier
+
+                await Task.Delay(_joinDelayJittered, _cancelToken);
             }
             else
             {

--- a/Scraps/Services/RaffleService.cs
+++ b/Scraps/Services/RaffleService.cs
@@ -193,7 +193,7 @@ public class RaffleService : IDisposable
                 Broadcast("Waiting to scan again");
 
                 System.Random _randomifier = new System.Random();
-                int _modifier = _randomifier.Next(-30000, 30000); // Adds a 30 second positive or negative delay. 
+                int _modifier = _randomifier.Next(0, 60000); // Adds up to a 60 second delay. 
 
                 int _scanDelayJittered = _scanDelay + _modifier;
 

--- a/Scraps/Services/SettingsService.cs
+++ b/Scraps/Services/SettingsService.cs
@@ -35,6 +35,8 @@ public class SettingsService
     private const int    ScanDelay             = 5000;
     private const int    PaginateDelay         = 500;
     private const int    JoinDelay             = 4000;
+    private const int    JoinJitter            = 0;
+    private const int    ScanJitter            = 0;
     private const bool   IncrementScanDelay    = true;
     private const bool   SortByNew             = true;
     private const bool   Paranoid              = false;


### PR DESCRIPTION
Hello! This is a small change to RaffleService to add some minor randomisation to the delays, after a friend of mine suggested it. 

Simply put, it varies how often it scans by up to 60 seconds each time, and raffle join frequency by up to 10 seconds, effectively turning. This has two benefits:

- It looks more natural in any server-side logs, and;
- It more accurately reflects the current climate of the site - raffles tend to be only a few per hour now, so scanning every 5 seconds is just overkill. 

No other changes are made other than this, but it seems like it could be useful so I figured I'd throw a PR in rather than keep it as an offshoot. Thanks!  